### PR TITLE
`kernelle version` Command: Vertically integrate versioning for the toolshed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 ]
 
 [workspace.package]
+version = "0.1.0"
 edition = "2021"
 authors = ["Jeff <jeffhilton.ctr@gmail.com>"]
 license = "Private"

--- a/crates/adam/Cargo.toml
+++ b/crates/adam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adam"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/bentley/Cargo.toml
+++ b/crates/bentley/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bentley"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/blizz/Cargo.toml
+++ b/crates/blizz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blizz"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/jerrod/Cargo.toml
+++ b/crates/jerrod/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "jerrod"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
 description = "GitLab and GitHub merge request review tool - the reliable guardian of code quality"
 
 [[bin]]

--- a/crates/kernelle/Cargo.toml
+++ b/crates/kernelle/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "kernelle"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
 description = "Kernelle toolshed package manager and workflow orchestrator"
-authors = ["Kernelle Team"]
 
 [[bin]]
 name = "kernelle"

--- a/crates/kernelle/src/commands/mod.rs
+++ b/crates/kernelle/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod r#do;
 pub mod remove;
 pub mod retrieve;
 pub mod store;
+pub mod version;

--- a/crates/kernelle/src/commands/version.rs
+++ b/crates/kernelle/src/commands/version.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+
+/// Execute version command
+pub async fn execute(list: bool) -> Result<()> {
+  if list {
+    show_available_versions().await
+  } else {
+    show_current_version().await
+  }
+}
+
+/// Show the current version
+async fn show_current_version() -> Result<()> {
+  let version = env!("CARGO_PKG_VERSION");
+  println!("kernelle {}", version);
+  Ok(())
+}
+
+/// Show all available versions from GitHub releases
+async fn show_available_versions() -> Result<()> {
+  let current_version = env!("CARGO_PKG_VERSION");
+  println!("Current version: kernelle {}", current_version);
+  println!();
+  
+  // TODO: Implement GitHub API call to fetch available releases
+  println!("Available versions:");
+  println!("  v0.1.0 (current)");
+  println!();
+  println!("Note: Release listing not yet implemented");
+  
+  Ok(())
+} 

--- a/crates/kernelle/src/commands/version.rs
+++ b/crates/kernelle/src/commands/version.rs
@@ -1,32 +1,82 @@
 use anyhow::Result;
+use std::io::Write;
 
 /// Execute version command
 pub async fn execute(list: bool) -> Result<()> {
+  let mut stdout = std::io::stdout();
   if list {
-    show_available_versions().await
+    show_available_versions(&mut stdout).await
   } else {
-    show_current_version().await
+    show_current_version(&mut stdout).await
   }
 }
 
 /// Show the current version
-async fn show_current_version() -> Result<()> {
+async fn show_current_version<W: Write>(writer: &mut W) -> Result<()> {
   let version = env!("CARGO_PKG_VERSION");
-  println!("kernelle {}", version);
+  writeln!(writer, "kernelle {version}")?;
   Ok(())
 }
 
 /// Show all available versions from GitHub releases
-async fn show_available_versions() -> Result<()> {
+async fn show_available_versions<W: Write>(writer: &mut W) -> Result<()> {
   let current_version = env!("CARGO_PKG_VERSION");
-  println!("Current version: kernelle {}", current_version);
-  println!();
-  
+  writeln!(writer, "Current version: kernelle {current_version}")?;
+  writeln!(writer)?;
+
   // TODO: Implement GitHub API call to fetch available releases
-  println!("Available versions:");
-  println!("  v0.1.0 (current)");
-  println!();
-  println!("Note: Release listing not yet implemented");
-  
+  writeln!(writer, "Available versions:")?;
+  writeln!(writer, "  {current_version} (current)")?;
+  writeln!(writer)?;
+  writeln!(writer, "Note: Release listing not yet implemented")?;
+
   Ok(())
-} 
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[tokio::test]
+  async fn test_show_current_version() -> Result<()> {
+    // Test that show_current_version outputs the correct version
+    let mut output = Vec::new();
+    let result = show_current_version(&mut output).await;
+
+    assert!(result.is_ok());
+    let output_str = String::from_utf8(output)?;
+    let expected_version = env!("CARGO_PKG_VERSION");
+    assert!(output_str.contains(&format!("kernelle {expected_version}")));
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn test_show_available_versions() -> Result<()> {
+    // Test that show_available_versions outputs the current version
+    let mut output = Vec::new();
+    let result = show_available_versions(&mut output).await;
+
+    assert!(result.is_ok());
+    let output_str = String::from_utf8(output)?;
+    let expected_version = env!("CARGO_PKG_VERSION");
+    assert!(output_str.contains(&format!("Current version: kernelle {expected_version}")));
+    assert!(output_str.contains("Available versions:"));
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn test_execute_basic_version() -> Result<()> {
+    // Test version command without list flag
+    let result = execute(false).await;
+    assert!(result.is_ok());
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn test_execute_version_list() -> Result<()> {
+    // Test version command with list flag
+    let result = execute(true).await;
+    assert!(result.is_ok());
+    Ok(())
+  }
+}

--- a/crates/kernelle/src/main.rs
+++ b/crates/kernelle/src/main.rs
@@ -70,6 +70,12 @@ enum Commands {
     #[arg(long)]
     verbose: bool,
   },
+  /// Show version information
+  Version {
+    /// List all available releases
+    #[arg(long)]
+    list: bool,
+  },
 }
 
 #[derive(Subcommand)]
@@ -95,6 +101,7 @@ async fn main() -> Result<()> {
     Commands::Retrieve { key } => commands::retrieve::execute(&key).await,
     Commands::Do { name, args, silent, file } => execute_task(&name, &args, silent, file).await,
     Commands::Tasks { file, verbose } => list_tasks(file, verbose).await,
+    Commands::Version { list } => commands::version::execute(list).await,
   }
 }
 

--- a/crates/sentinel/Cargo.toml
+++ b/crates/sentinel/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "sentinel"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "Secure credential storage for Kernelle tools - the watchful guardian of secrets"
 
 [[bin]]

--- a/crates/violet/Cargo.toml
+++ b/crates/violet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "violet"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
# Pull Request

This PR makes all cargo crate versions in the repo are tethered to the workspace version, and adds a `kernelle version` command to access the version information.

## Testing
- [x] I have run `kernelle do checks` and all checks pass

## Checklist
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] Code follows Rust formatting standards (`kernelle do format`)
- [x] Any dependent changes have been merged and published

## Additional Notes
Step 1 of toolshed release/versioning plan: https://github.com/TravelSizedLions/kernelle/issues/9#issuecomment-3110107372
