### PR TITLE
Taskrunner multi-line syntax 

### DIFF
--- a/.cursor/kernelle.yaml
+++ b/.cursor/kernelle.yaml
@@ -2,6 +2,13 @@
 # Personal workflow shortcuts and development tasks
 
 # Git Tasks
-git_cleanup: "git checkout dev && git branch | grep -v \"dev\" | xargs git branch -D"
+git_cleanup: 
+  - git checkout dev 
+  - git branch | grep -v \"dev\" | xargs git branch -D
 
-tweak: "kernelle do tidy && kernelle do checks && git add . && git commit -m \"tweaks\" && git push"
+tweak: 
+  - kernelle do tidy 
+  - kernelle do checks 
+  - git add . 
+  - git commit -m \"tweaks\" 
+  - git push

--- a/.cursor/kernelle.yaml
+++ b/.cursor/kernelle.yaml
@@ -2,7 +2,7 @@
 # Personal workflow shortcuts and development tasks
 
 # Git Tasks
-git_cleanup: 
+git-cleanup: 
   - git checkout dev 
   - git branch | grep -v \"dev\" | xargs git branch -D
 

--- a/.github/workflows/quality-control.yml
+++ b/.github/workflows/quality-control.yml
@@ -25,4 +25,4 @@ jobs:
           rust-components: rustfmt,clippy
 
       - name: Check Tidiness
-        run: kernelle do check:tidy
+        run: kernelle do check-tidy

--- a/crates/kernelle/src/commands/do.rs
+++ b/crates/kernelle/src/commands/do.rs
@@ -20,9 +20,9 @@ impl<'de> Deserialize<'de> for TaskCommand {
     D: Deserializer<'de>,
   {
     use serde::de::Error;
-    
+
     let value = serde_yaml::Value::deserialize(deserializer)?;
-    
+
     match value {
       serde_yaml::Value::String(s) => Ok(TaskCommand::String(s)),
       serde_yaml::Value::Sequence(seq) => {
@@ -113,29 +113,40 @@ fn load_tasks_file(path: &str) -> Result<TasksFile> {
     .map_err(|e| anyhow!("Failed to parse YAML in tasks file '{}': {}", path, e))?;
 
   // Convert to our TasksFile format
-  let mapping = yaml_value.as_mapping()
+  let mapping = yaml_value
+    .as_mapping()
     .ok_or_else(|| anyhow!("Tasks file '{}' must contain a YAML mapping at the root", path))?;
 
   let mut tasks = HashMap::new();
-  
+
   for (key, value) in mapping {
-    let key_str = key.as_str()
-      .ok_or_else(|| anyhow!("Task names must be strings in file '{}'", path))?;
-    
+    let key_str =
+      key.as_str().ok_or_else(|| anyhow!("Task names must be strings in file '{}'", path))?;
+
     let task_command = match value {
       serde_yaml::Value::String(s) => TaskCommand::String(s.clone()),
       serde_yaml::Value::Sequence(seq) => {
         let strings: Result<Vec<String>, _> = seq
           .iter()
-          .map(|v| v.as_str()
-            .ok_or_else(|| anyhow!("Array elements must be strings for task '{}' in file '{}'", key_str, path))
-            .map(|s| s.to_string()))
+          .map(|v| {
+            v.as_str()
+              .ok_or_else(|| {
+                anyhow!("Array elements must be strings for task '{}' in file '{}'", key_str, path)
+              })
+              .map(|s| s.to_string())
+          })
           .collect();
         TaskCommand::Array(strings?)
       }
-      _ => return Err(anyhow!("Task '{}' in file '{}' must be a string or array of strings", key_str, path)),
+      _ => {
+        return Err(anyhow!(
+          "Task '{}' in file '{}' must be a string or array of strings",
+          key_str,
+          path
+        ))
+      }
     };
-    
+
     tasks.insert(key_str.to_string(), task_command);
   }
 
@@ -315,5 +326,231 @@ mod tests {
     // This will depend on the actual environment, so we just ensure it doesn't panic
     let _is_ci = is_ci_environment();
     // Function should not panic and should return a boolean
+  }
+
+  #[test]
+  fn test_task_command_string_to_command_string() {
+    // Test TaskCommand::String converts correctly
+    let string_task = TaskCommand::String("echo hello".to_string());
+    assert_eq!(string_task.to_command_string(), "echo hello");
+  }
+
+  #[test]
+  fn test_task_command_array_to_command_string() {
+    // Test TaskCommand::Array converts correctly with && joining
+    let array_task = TaskCommand::Array(vec![
+      "echo first".to_string(),
+      "echo second".to_string(),
+      "echo third".to_string(),
+    ]);
+    assert_eq!(array_task.to_command_string(), "echo first && echo second && echo third");
+  }
+
+  #[test]
+  fn test_task_command_empty_array() {
+    // Test TaskCommand::Array with empty array
+    let empty_array_task = TaskCommand::Array(vec![]);
+    assert_eq!(empty_array_task.to_command_string(), "");
+  }
+
+  #[test]
+  fn test_task_command_single_item_array() {
+    // Test TaskCommand::Array with single item should not add &&
+    let single_array_task = TaskCommand::Array(vec!["echo single".to_string()]);
+    assert_eq!(single_array_task.to_command_string(), "echo single");
+  }
+
+  #[test]
+  fn test_load_tasks_file_with_string_commands() {
+    // Test loading a YAML file with string commands
+    use std::fs;
+    use std::path::Path;
+    use tempfile::NamedTempFile;
+
+    let yaml_content = r#"
+build: "cargo build"
+test: "cargo test"
+clean: "cargo clean"
+"#;
+
+    let temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), yaml_content).unwrap();
+
+    let result = load_tasks_file(temp_file.path().to_str().unwrap());
+    assert!(result.is_ok());
+
+    let tasks = result.unwrap();
+    assert_eq!(tasks.len(), 3);
+
+    // Check that string commands are parsed correctly
+    if let Some(TaskCommand::String(cmd)) = tasks.get("build") {
+      assert_eq!(cmd, "cargo build");
+    } else {
+      panic!("Expected TaskCommand::String for 'build' task");
+    }
+
+    if let Some(TaskCommand::String(cmd)) = tasks.get("test") {
+      assert_eq!(cmd, "cargo test");
+    } else {
+      panic!("Expected TaskCommand::String for 'test' task");
+    }
+  }
+
+  #[test]
+  fn test_load_tasks_file_with_array_commands() {
+    // Test loading a YAML file with array commands
+    use std::fs;
+    use tempfile::NamedTempFile;
+
+    let yaml_content = r#"
+tidy:
+  - "cargo fmt"
+  - "cargo clippy"
+checks:
+  - "cargo build"
+  - "cargo test"
+  - "cargo audit"
+"#;
+
+    let temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), yaml_content).unwrap();
+
+    let result = load_tasks_file(temp_file.path().to_str().unwrap());
+    assert!(result.is_ok());
+
+    let tasks = result.unwrap();
+    assert_eq!(tasks.len(), 2);
+
+    // Check that array commands are parsed correctly
+    if let Some(TaskCommand::Array(cmds)) = tasks.get("tidy") {
+      assert_eq!(cmds.len(), 2);
+      assert_eq!(cmds[0], "cargo fmt");
+      assert_eq!(cmds[1], "cargo clippy");
+    } else {
+      panic!("Expected TaskCommand::Array for 'tidy' task");
+    }
+
+    if let Some(TaskCommand::Array(cmds)) = tasks.get("checks") {
+      assert_eq!(cmds.len(), 3);
+      assert_eq!(cmds[0], "cargo build");
+      assert_eq!(cmds[1], "cargo test");
+      assert_eq!(cmds[2], "cargo audit");
+    } else {
+      panic!("Expected TaskCommand::Array for 'checks' task");
+    }
+  }
+
+  #[test]
+  fn test_load_tasks_file_with_mixed_commands() {
+    // Test loading a YAML file with both string and array commands
+    use std::fs;
+    use tempfile::NamedTempFile;
+
+    let yaml_content = r#"
+build: "cargo build"
+tidy:
+  - "cargo fmt"
+  - "cargo clippy"
+test: "cargo test"
+full_check:
+  - "cargo build"
+  - "cargo test"
+  - "cargo audit"
+"#;
+
+    let temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), yaml_content).unwrap();
+
+    let result = load_tasks_file(temp_file.path().to_str().unwrap());
+    assert!(result.is_ok());
+
+    let tasks = result.unwrap();
+    assert_eq!(tasks.len(), 4);
+
+    // Check string commands
+    assert!(matches!(tasks.get("build"), Some(TaskCommand::String(_))));
+    assert!(matches!(tasks.get("test"), Some(TaskCommand::String(_))));
+
+    // Check array commands
+    assert!(matches!(tasks.get("tidy"), Some(TaskCommand::Array(_))));
+    assert!(matches!(tasks.get("full_check"), Some(TaskCommand::Array(_))));
+
+    // Verify command string generation works correctly for both types
+    assert_eq!(tasks.get("build").unwrap().to_command_string(), "cargo build");
+    assert_eq!(tasks.get("tidy").unwrap().to_command_string(), "cargo fmt && cargo clippy");
+    assert_eq!(tasks.get("full_check").unwrap().to_command_string(), "cargo build && cargo test && cargo audit");
+  }
+
+  #[test]
+  fn test_load_tasks_file_with_invalid_yaml() {
+    // Test error handling for invalid YAML
+    use std::fs;
+    use tempfile::NamedTempFile;
+
+    let invalid_yaml = r#"
+build: "cargo build"
+invalid:
+  - this
+  - is
+  - 123
+  - valid: but this creates nested structure
+"#;
+
+    let temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), invalid_yaml).unwrap();
+
+    let result = load_tasks_file(temp_file.path().to_str().unwrap());
+    assert!(result.is_err());
+
+    let error_message = result.unwrap_err().to_string();
+    assert!(error_message.contains("Array elements must be strings"));
+  }
+
+  #[test]
+  fn test_load_tasks_file_with_task_names_containing_special_chars() {
+    // Test that task names with colons and other special characters work when quoted properly
+    use std::fs;
+    use tempfile::NamedTempFile;
+
+    let yaml_content = r#"
+"task:with:colons": "echo hello"
+"task-with-dashes": "echo world"
+task_with_underscores: "echo test"
+array_task:
+  - "echo first"
+  - "echo second"
+"#;
+
+    let temp_file = NamedTempFile::new().unwrap();
+    fs::write(temp_file.path(), yaml_content).unwrap();
+
+    let result = load_tasks_file(temp_file.path().to_str().unwrap());
+    assert!(result.is_ok());
+
+    let tasks = result.unwrap();
+    assert_eq!(tasks.len(), 4);
+
+    // Check that task names with special characters are preserved
+    assert!(tasks.contains_key("task:with:colons"));
+    assert!(tasks.contains_key("task-with-dashes"));
+    assert!(tasks.contains_key("task_with_underscores"));
+    assert!(tasks.contains_key("array_task"));
+  }
+
+  #[test]
+  fn test_task_command_serialization() {
+    // Test that TaskCommand can be serialized and deserialized correctly
+    use serde_yaml;
+
+    // Test string variant
+    let string_task = TaskCommand::String("echo hello".to_string());
+    let yaml_str = serde_yaml::to_string(&string_task).unwrap();
+    assert_eq!(yaml_str.trim(), "echo hello");
+
+    // Test array variant
+    let array_task = TaskCommand::Array(vec!["echo first".to_string(), "echo second".to_string()]);
+    let yaml_str = serde_yaml::to_string(&array_task).unwrap();
+    assert!(yaml_str.contains("- echo first"));
+    assert!(yaml_str.contains("- echo second"));
   }
 }

--- a/crates/kernelle/src/main.rs
+++ b/crates/kernelle/src/main.rs
@@ -141,7 +141,8 @@ async fn list_tasks(file: Option<String>, verbose: bool) -> Result<()> {
     for (name, command) in sorted_tasks {
       let dots_count = max_name_length - name.len() + 4; // +4 for some padding
       let dots = "·".repeat(dots_count);
-      println!("• {name} {dots} {command}");
+      let command_display = command.to_command_string();
+      println!("• {name} {dots} {command_display}");
     }
   } else {
     let mut tasks = commands::r#do::list_tasks(file).await?;

--- a/kernelle.yaml
+++ b/kernelle.yaml
@@ -3,27 +3,27 @@
 # ------------------------------------------------------------
 
 # PR Pre-checks
-checks: 
-  - kernelle do checks:base
+checks:
+  - kernelle do checks-base
   - kernelle do test
 
-checks:full: 
-  - kernelle do checks:base 
+checks-full:
+  - kernelle do checks-base
   - kernelle do coverage
 
 # Other Useful Tasks
-build: "kernelle do rust:build"
-clean: "kernelle do rust:clean"
-audit: "kernelle do rust:audit"
-test: "kernelle do rust:test"
-coverage: "kernelle do rust:coverage"
+build: "kernelle do rust-build"
+clean: "kernelle do rust-clean"
+audit: "kernelle do rust-audit"
+test: "kernelle do rust-test"
+coverage: "kernelle do rust-coverage"
 endlines: "bash scripts/ensure-final-newlines.sh --fix"
-lint: "kernelle do rust:lint"
+lint: "kernelle do rust-lint"
 tidy: 
   - kernelle do lint
   - kernelle do format
 format: 
-  - kernelle do rust:format 
+  - kernelle do rust-format
   - kernelle do endlines
 
 # ------------------------------------------------------------
@@ -33,47 +33,47 @@ format:
 # Note: for now, these are mostly just aliases for rust tasks, but eventually python will be added to the mix
 
 # Base pre-checks, built from other checks below
-checks:base: 
-  - kernelle do check:build 
-  - kernelle do check:tidy
+checks-base: 
+  - kernelle do check-build
+  - kernelle do check-tidy
 
-check:build: "kernelle do build"
-check:secure: "kernelle do rust:audit"
-check:test: "NO_COLOR=1 kernelle do rust:test"
+check-build: "kernelle do build"
+check-secure: "kernelle do rust-audit"
+check-test: "NO_COLOR=1 kernelle do rust-test"
 
-check:tidy: 
-  - kernelle do check:lint 
-  - kernelle do check:format 
-  - kernelle do check:endlines 
-  - kernelle do check:reading
+check-tidy: 
+  - kernelle do check-lint 
+  - kernelle do check-format 
+  - kernelle do check-endlines 
+  - kernelle do check-reading
 
-check:reading: "violet ."
-check:lint: "kernelle do rust:lint:assert"
-check:format: "kernelle do rust:format:assert"
-check:endlines: "bash scripts/ensure-final-newlines.sh --check"
+check-reading: "violet ."
+check-lint: "kernelle do rust-lint-assert"
+check-format: "kernelle do rust-format-assert"
+check-endlines: "bash scripts/ensure-final-newlines.sh --check"
 
 # ------------------------------------------------------------
 # Rust Tasks
 # ------------------------------------------------------------
 
 # Lint & Format (Fix)
-rust:lint: "cargo clippy --workspace --all-targets --all-features --fix --allow-dirty --allow-staged"
-rust:format: "cargo fmt --all"
+rust-lint: "cargo clippy --workspace --all-targets --all-features --fix --allow-dirty --allow-staged"
+rust-format: "cargo fmt --all"
 
 # Lint & Format (Assert)
-rust:lint:assert: "RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets --all-features"
-rust:format:assert: "cargo fmt --all -- --check"
+rust-lint-assert: "RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets --all-features"
+rust-format-assert: "cargo fmt --all -- --check"
 
 # Build and/or clean the Rust code
-rust:build: "cargo build --release"
-rust:clean: "cargo clean"
-rust:build:clean: 
-  - kernelle do rust:clean 
-  - kernelle do rust:build
+rust-build: "cargo build --release"
+rust-clean: "cargo clean"
+rust-build-clean: 
+  - kernelle do rust-clean
+  - kernelle do rust-build
 
 # Security Audit
-rust:audit: "cargo audit --deny warnings --deny unmaintained"
+rust-audit: "cargo audit --deny warnings --deny unmaintained"
 
 # Testing
-rust:test: "cargo test --workspace"
-rust:coverage: "cargo tarpaulin --workspace --timeout 300 --out xml --output-dir coverage"
+rust-test: "cargo test --workspace"
+rust-coverage: "cargo tarpaulin --workspace --timeout 300 --out xml --output-dir coverage"

--- a/kernelle.yaml
+++ b/kernelle.yaml
@@ -3,19 +3,28 @@
 # ------------------------------------------------------------
 
 # PR Pre-checks
-checks: "kernelle do checks:base && kernelle do test"
-checks:full: "kernelle do checks:base && kernelle do coverage"
+checks: 
+  - kernelle do checks:base
+  - kernelle do test
+
+checks:full: 
+  - kernelle do checks:base 
+  - kernelle do coverage
 
 # Other Useful Tasks
 build: "kernelle do rust:build"
 clean: "kernelle do rust:clean"
-tidy: "kernelle do lint && kernelle do format"
-lint: "kernelle do rust:lint"
-format: "kernelle do rust:format && kernelle do endlines"
 audit: "kernelle do rust:audit"
 test: "kernelle do rust:test"
 coverage: "kernelle do rust:coverage"
 endlines: "bash scripts/ensure-final-newlines.sh --fix"
+lint: "kernelle do rust:lint"
+tidy: 
+  - kernelle do lint
+  - kernelle do format
+format: 
+  - kernelle do rust:format 
+  - kernelle do endlines
 
 # ------------------------------------------------------------
 # Pre-check Tasks
@@ -23,13 +32,21 @@ endlines: "bash scripts/ensure-final-newlines.sh --fix"
 # These subtasks will be used to orchestrate linting, formatting, and other checks for PRs 
 # Note: for now, these are mostly just aliases for rust tasks, but eventually python will be added to the mix
 
-checks:base: "kernelle do check:build && kernelle do check:tidy" # Base pre-checks, built from other checks below
+# Base pre-checks, built from other checks below
+checks:base: 
+  - kernelle do check:build 
+  - kernelle do check:tidy
 
 check:build: "kernelle do build"
 check:secure: "kernelle do rust:audit"
 check:test: "NO_COLOR=1 kernelle do rust:test"
 
-check:tidy: "kernelle do check:lint && kernelle do check:format && kernelle do check:endlines && kernelle do check:reading"
+check:tidy: 
+  - kernelle do check:lint 
+  - kernelle do check:format 
+  - kernelle do check:endlines 
+  - kernelle do check:reading
+
 check:reading: "violet ."
 check:lint: "kernelle do rust:lint:assert"
 check:format: "kernelle do rust:format:assert"
@@ -50,7 +67,9 @@ rust:format:assert: "cargo fmt --all -- --check"
 # Build and/or clean the Rust code
 rust:build: "cargo build --release"
 rust:clean: "cargo clean"
-rust:build:clean: "kernelle do rust:clean && kernelle do rust:build"
+rust:build:clean: 
+  - kernelle do rust:clean 
+  - kernelle do rust:build
 
 # Security Audit
 rust:audit: "cargo audit --deny warnings --deny unmaintained"


### PR DESCRIPTION
# Pull Request

Makes it possible to break up &&'d tasks into separate lines in a YAML array. Syntactically:

```
hello:
  - echo 'hello'
  - echo 'world'
```

Is identical to `echo 'hello' && echo 'world'`

## Checklist
- [x] I have run `kernelle do checks` and all checks pass
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] Any dependent changes have been merged and published
