### PR TITLE
Release Workflow, triggered by version tag

### DIFF
--- a/.github/run/assert-version-match.sh
+++ b/.github/run/assert-version-match.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify that git tag version matches Cargo.toml version
+# Usage: verify-version.sh <tag_version>
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <tag_version>"
+  echo "Example: $0 0.1.1"
+  exit 1
+fi
+
+TAG_VERSION="$1"
+
+echo "🔍 Verifying version consistency"
+
+# Extract version from workspace Cargo.toml
+# Look for version in [workspace.package] section
+CARGO_VERSION=$(awk '/^\[workspace\.package\]/{flag=1; next} /^\[/{flag=0} flag && /^version = /{gsub(/["[:space:]]/, "", $3); print $3}' Cargo.toml)
+
+echo "📦 Cargo.toml version: $CARGO_VERSION"
+echo "🏷️  Git tag version: $TAG_VERSION"
+
+if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
+  echo "❌ Version mismatch detected!"
+  echo "   Cargo.toml has version: $CARGO_VERSION"
+  echo "   Git tag has version: $TAG_VERSION"
+  echo ""
+  echo "💡 To fix this:"
+  echo "   1. Update Cargo.toml version to match tag, OR"
+  echo "   2. Create a new tag with the correct version"
+  exit 1
+fi
+
+echo "✅ Version verified: $CARGO_VERSION matches tag" 

--- a/.github/run/create-archive.sh
+++ b/.github/run/create-archive.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create source archives for kernelle releases
+# Usage: create-source-archive.sh <tag>
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <tag>"
+  echo "Example: $0 v0.1.1"
+  exit 1
+fi
+
+TAG="$1"
+ARCHIVE_NAME="kernelle-${TAG}-source"
+
+echo "📦 Creating source archives for $TAG"
+
+# Create clean source archives using git archive
+echo "🗜️  Creating tar.gz archive..."
+git archive --format=tar.gz --prefix="${ARCHIVE_NAME}/" HEAD > "${ARCHIVE_NAME}.tar.gz"
+
+echo "🗜️  Creating zip archive..."  
+git archive --format=zip --prefix="${ARCHIVE_NAME}/" HEAD > "${ARCHIVE_NAME}.zip"
+
+# Verify archives were created and show sizes
+echo "✅ Archives created successfully:"
+ls -lh "${ARCHIVE_NAME}".{tar.gz,zip}
+
+# Show what's included in the archives (first few entries)
+echo ""
+echo "📋 Archive contents preview:"
+echo "tar.gz contents:"
+tar -tzf "${ARCHIVE_NAME}.tar.gz" | head -10
+echo "..."
+
+echo ""
+echo "🎉 Source archives ready for release!" 

--- a/.github/run/create-coverage-badge.sh
+++ b/.github/run/create-coverage-badge.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Extract the badge line (first line) from the coverage results
+NEW_BADGE=$(head -n 1 code-coverage-results.md)
+
+# Replace the coverage badge line in README.md
+sed -i "s|^!\[Code Coverage\](https://img\.shields\.io/badge/.*|$NEW_BADGE|" README.md
+
+# Check if there were changes
+if git diff --quiet README.md; then
+  echo "No changes to README.md"
+else
+  echo "Coverage badge updated in README.md"
+  git config --local user.email "action@github.com"
+  git config --local user.name "GitHub Action"
+  git add README.md
+  git commit -m "Update coverage badge [skip ci]"
+  git push
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Get Release Version
+        id: version
+        run: |
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      
+      - name: Verify Release Version Matches Cargo.toml
+        run: .github/run/assert-version-match.sh \
+          "${{ steps.version.outputs.version }}"
+     
+      - name: Create Release Archive
+        run: .github/run/create-archive.sh \
+          "${{ steps.version.outputs.tag }}"
+      
+      - name: Generate Release Notes
+        run: .github/run/create-release-notes.sh \
+          "${{ steps.version.outputs.tag }}" \
+          "${{ steps.version.outputs.version }}"
+      
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Kernelle ${{ steps.version.outputs.version }}
+          body_path: release_notes.md
+          files: |
+            kernelle-${{ steps.version.outputs.tag }}-source.tar.gz
+            kernelle-${{ steps.version.outputs.tag }}-source.zip
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
# Pull Request

This PR adds a github workflow to create an official release when pushing a version tag

## Checklist
- [x] I have run `kernelle do checks` and all checks pass
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] Any dependent changes have been merged and published