### PR TITLE
Restructuring kernelle folder structure for better user data safety

### DIFF
--- a/crates/blizz/src/insight.rs
+++ b/crates/blizz/src/insight.rs
@@ -183,7 +183,7 @@ pub fn clear_embedding(insight: &mut Insight) {
   insight.embedding_computed = None;
 }
 
-pub fn delete(insight: &Insight) -> Result<()> {
+pub fn dv/source.ielete(insight: &Insight) -> Result<()> {
   let file_path = file_path(insight)?;
   check_insight_exists(&file_path, &insight.topic, &insight.name)?;
   fs::remove_file(&file_path)?;
@@ -198,7 +198,7 @@ pub fn get_insights_root() -> Result<PathBuf> {
   }
 
   let home = home_dir().ok_or_else(|| anyhow!("Could not find home directory"))?;
-  Ok(home.join(".kernelle").join("insights"))
+  Ok(home.join(".kernelle").join("persistent").join("blizz").join("insights"))
 }
 
 pub fn get_valid_insights_dir() -> Result<std::path::PathBuf> {

--- a/crates/blizz/src/insight.rs
+++ b/crates/blizz/src/insight.rs
@@ -183,7 +183,7 @@ pub fn clear_embedding(insight: &mut Insight) {
   insight.embedding_computed = None;
 }
 
-pub fn dv/source.ielete(insight: &Insight) -> Result<()> {
+pub fn delete(insight: &Insight) -> Result<()> {
   let file_path = file_path(insight)?;
   check_insight_exists(&file_path, &insight.topic, &insight.name)?;
   fs::remove_file(&file_path)?;

--- a/crates/kernelle/src/commands/add.rs
+++ b/crates/kernelle/src/commands/add.rs
@@ -48,11 +48,11 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
 pub async fn execute(target_dir: &str) -> Result<()> {
   let target_path = Path::new(target_dir);
   let kernelle_home = get_kernelle_home()?;
-  let cursor_source = kernelle_home.join(".cursor").join("rules").join("kernelle");
+  let cursor_source = kernelle_home.join("volatile").join(".cursor").join("rules").join("kernelle");
 
   if !cursor_source.exists() {
     anyhow::bail!(
-            "Kernelle cursor workflows not found at {}/.cursor/rules/kernelle\nPlease run the Kernelle setup script first.",
+            "Kernelle cursor workflows not found at {}/volatile/.cursor/rules/kernelle\nPlease run the Kernelle setup script first.",
             kernelle_home.display()
         );
   }
@@ -65,7 +65,7 @@ pub async fn execute(target_dir: &str) -> Result<()> {
 
   println!("Adding Kernelle cursor workflows to {}...", target_path.display());
 
-  // Create single symlink: .cursor/rules/kernelle/ -> ~/.kernelle/.cursor/rules/kernelle/
+  // Create single symlink: .cursor/rules/kernelle/ -> ~/.kernelle/volatile/.cursor/rules/kernelle/
   let kernelle_link = rules_target.join("kernelle");
 
   // Remove existing kernelle symlink/directory if it exists

--- a/crates/kernelle/src/commands/remove.rs
+++ b/crates/kernelle/src/commands/remove.rs
@@ -17,10 +17,14 @@ pub async fn execute(target_dir: &str) -> Result<()> {
 
   // Check for the kernelle symlink in .cursor/rules/
   let kernelle_link = rules_dir.join("kernelle");
-  let kernelle_cursor_path = kernelle_home.join(".cursor").join("rules").join("kernelle");
+  let kernelle_cursor_path = kernelle_home
+    .join("volatile")
+    .join(".cursor")
+    .join("rules")
+    .join("kernelle");
 
   if kernelle_link.exists() && kernelle_link.is_symlink() {
-    // Check if it points to ~/.kernelle/.cursor/rules/kernelle
+    // Check if it points to ~/.kernelle/volatile/.cursor/rules/kernelle
     if let Ok(target) = fs::read_link(&kernelle_link) {
       if target == kernelle_cursor_path {
         fs::remove_file(&kernelle_link)

--- a/crates/kernelle/src/commands/remove.rs
+++ b/crates/kernelle/src/commands/remove.rs
@@ -17,11 +17,8 @@ pub async fn execute(target_dir: &str) -> Result<()> {
 
   // Check for the kernelle symlink in .cursor/rules/
   let kernelle_link = rules_dir.join("kernelle");
-  let kernelle_cursor_path = kernelle_home
-    .join("volatile")
-    .join(".cursor")
-    .join("rules")
-    .join("kernelle");
+  let kernelle_cursor_path =
+    kernelle_home.join("volatile").join(".cursor").join("rules").join("kernelle");
 
   if kernelle_link.exists() && kernelle_link.is_symlink() {
     // Check if it points to ~/.kernelle/volatile/.cursor/rules/kernelle

--- a/crates/sentinel/src/lib.rs
+++ b/crates/sentinel/src/lib.rs
@@ -242,7 +242,8 @@ impl PasswordBasedCryptoManager {
     };
 
     let mut credentials_path = base_path;
-    credentials_path.push("sentinel");
+    credentials_path.push("persistent");
+    credentials_path.push("keeper");
     credentials_path.push("credentials.enc");
 
     Self { credentials_path }

--- a/kernelle.yaml
+++ b/kernelle.yaml
@@ -45,6 +45,7 @@ checks-base:
   - do: check-tidy
 
 check-build: 
+  - do: clean
   - do: build
 check-secure: 
   - do: rust-audit

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -199,7 +199,9 @@ KERNELLE_HOME="${KERNELLE_HOME:-$HOME/.kernelle}"
 
 # Create directories
 echo "📁 Creating directories..."
-mkdir -p "$KERNELLE_HOME"
+mkdir -p "$KERNELLE_HOME/persistent/blizz"
+mkdir -p "$KERNELLE_HOME/persistent/keeper" 
+mkdir -p "$KERNELLE_HOME/volatile"
 
 # For Phase 1, we'll assume we're running from the source directory
 # In Phase 2+, this would clone from a repo
@@ -243,9 +245,9 @@ for crate_dir in crates/*/; do
 done
 
 echo "📋 Setting up workflows..."
-# Copy .cursor rules to ~/.kernelle/.cursor
+# Copy .cursor rules to ~/.kernelle/volatile/.cursor
 if [ -d "$REPO_ROOT/.cursor" ]; then
-    cp -r "$REPO_ROOT/.cursor" "$KERNELLE_HOME/"
+    cp -r "$REPO_ROOT/.cursor" "$KERNELLE_HOME/volatile/"
 else
     echo "⚠️  No .cursor directory found - workflows will not be available"
 fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -193,8 +193,8 @@ fi
 
 if [ "$keep_insights" = true ]; then
     echo "💾 Preserving insights..."
-    if [ -d "$KERNELLE_HOME/insights" ]; then
-        mv "$KERNELLE_HOME/insights" "$HOME/.kernelle-insights-backup" || true
+    if [ -d "$KERNELLE_HOME/persistent/blizz/insights" ]; then
+        mv "$KERNELLE_HOME/persistent/blizz/insights" "$HOME/.kernelle-insights-backup" || true
         echo "✓ Insights backed up to ~/.kernelle-insights-backup"
     fi
 fi
@@ -203,8 +203,8 @@ echo "🗑️  Removing global insights..."
 rm -rf "$KERNELLE_HOME/global-insights" 2>/dev/null || true
 
 echo "🔗 Removing cursor workflow symlinks..."
-# Find all symlinks that point to ~/.kernelle/.cursor (much more efficient!)
-find . -type l -lname "$KERNELLE_HOME/.cursor" 2>/dev/null | while read -r link; do
+# Find all symlinks that point to ~/.kernelle/volatile/.cursor (updated path)
+find . -type l -lname "$KERNELLE_HOME/volatile/.cursor" 2>/dev/null | while read -r link; do
     rm -f "$link"
     echo "  Removed: $link"
     
@@ -216,25 +216,27 @@ find . -type l -lname "$KERNELLE_HOME/.cursor" 2>/dev/null | while read -r link;
 done || true
 
 # Ask about preserving tweaks
-if [ -d "$KERNELLE_HOME/.cursor/tweaks" ]; then
+if [ -d "$KERNELLE_HOME/volatile/.cursor/tweaks" ]; then
     echo ""
-    echo "📁 Found custom tweaks directory: $KERNELLE_HOME/.cursor/tweaks"
+    echo "📁 Found custom tweaks directory: $KERNELLE_HOME/volatile/.cursor/tweaks"
     if [ "$NON_INTERACTIVE" = true ]; then
         # Non-interactive: always preserve tweaks (safer default)
-        mv "$KERNELLE_HOME/.cursor/tweaks" "$HOME/.kernelle-tweaks-backup"
+        mv "$KERNELLE_HOME/volatile/.cursor/tweaks" "$HOME/.kernelle-tweaks-backup"
         echo "🤖 Non-interactive mode: Tweaks backed up to ~/.kernelle-tweaks-backup"
     else
         if ask_yes_no "Do you want to preserve your custom tweaks?"; then
-            mv "$KERNELLE_HOME/.cursor/tweaks" "$HOME/.kernelle-tweaks-backup"
+            mv "$KERNELLE_HOME/volatile/.cursor/tweaks" "$HOME/.kernelle-tweaks-backup"
             echo "✓ Tweaks backed up to ~/.kernelle-tweaks-backup"
         fi
     fi
 fi
 
-echo "🗂️  Cleaning ~/.kernelle directory (keeping warning file)..."
-# Remove everything except the kernelle.internal.source warning file
+echo "🗂️  Cleaning ~/.kernelle directory (keeping persistent data)..."
+# Remove only volatile data and recreatable files - persistent/ is untouched!
 if [ -d "$KERNELLE_HOME" ]; then
-    find "$KERNELLE_HOME" -mindepth 1 ! -name "kernelle.internal.source" -exec rm -rf {} + 2>/dev/null || true
+    rm -rf "$KERNELLE_HOME/volatile" 2>/dev/null || true
+    rm -f "$KERNELLE_HOME/kernelle.internal.source" 2>/dev/null || true
+    # persistent/ directory is completely safe!
 fi
 
 echo "🗑️  Removing binaries from $INSTALL_DIR..."


### PR DESCRIPTION
# Pull Request

Addresses: https://github.com/TravelSizedLions/kernelle/issues/63

New Structure:
```bash
~/.kernelle/
├── persistent/          # User data that survives installs, uninstalls, and re-installs
│   ├── blizz/
│   │   └── insights/    # Blizz insights (was ~/.kernelle/insights/)
│   └── keeper/          # Sentinel credentials (was ~/.kernelle/sentinel/)
│       └── credentials.enc
└── volatile/            # System files that can be recreated
    └── .cursor          # Workflow file
```

## Checklist
- [x] I have run `kernelle do checks` and all checks pass
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] Any dependent changes have been merged and published