### PR TITLE
Add temporal metadata to insights

### DIFF
--- a/crates/insights/src/server/models/insight.rs
+++ b/crates/insights/src/server/models/insight.rs
@@ -5,6 +5,17 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
+// Default values for backwards compatibility with existing insight files
+fn default_created_at() -> DateTime<Utc> {
+  // For existing insights, use a reasonable fallback date
+  DateTime::parse_from_rfc3339("2025-05-01T00:00:00Z").unwrap().with_timezone(&Utc)
+}
+
+fn default_last_updated() -> DateTime<Utc> {
+  // For existing insights, use current time as last_updated
+  Utc::now()
+}
+
 // Frontmatter parsing constants
 const FRONTMATTER_START: &str = "---\n";
 const FRONTMATTER_END: &str = "\n---\n";
@@ -19,6 +30,16 @@ pub struct InsightMetaData {
   #[serde(default)]
   pub name: String,
   pub overview: String,
+  
+  // Temporal metadata - always included in files
+  #[serde(default = "default_created_at")]
+  pub created_at: DateTime<Utc>,
+  #[serde(default = "default_last_updated")]
+  pub last_updated: DateTime<Utc>,
+  #[serde(default)]
+  pub update_count: u32,
+  
+  // Embedding metadata - excluded from files (set to None in write_to_file)
   #[serde(skip_serializing_if = "Option::is_none")]
   pub embedding_version: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -36,6 +57,11 @@ pub struct Insight {
   pub overview: String,
   pub details: String,
 
+  // Temporal metadata
+  pub created_at: DateTime<Utc>,
+  pub last_updated: DateTime<Utc>,
+  pub update_count: u32,
+
   // Embedding metadata (None if not computed yet)
   pub embedding_version: Option<String>,
   pub embedding: Option<Vec<f32>>,
@@ -45,11 +71,15 @@ pub struct Insight {
 
 impl Insight {
   pub fn new(topic: String, name: String, overview: String, details: String) -> Self {
+    let now = Utc::now();
     Self {
       topic,
       name,
       overview,
       details,
+      created_at: now,
+      last_updated: now,
+      update_count: 0,
       embedding_version: None,
       embedding: None,
       embedding_text: None,
@@ -88,6 +118,10 @@ fn write_to_file(insight: &Insight, file_path: &PathBuf) -> Result<()> {
     topic: insight.topic.clone(),
     name: insight.name.clone(),
     overview: insight.overview.clone(),
+    // Include temporal metadata in files - useful for filtering and UX
+    created_at: insight.created_at,
+    last_updated: insight.last_updated,
+    update_count: insight.update_count,
     // Don't serialize embedding data to files - keep files human-readable
     // Embeddings are stored in LanceDB for search operations
     embedding_version: None,
@@ -138,6 +172,10 @@ pub fn update(
   if new_overview.is_none() && new_details.is_none() {
     return Err(anyhow!("At least one of overview or details must be provided"));
   }
+
+  // Update temporal metadata
+  insight.last_updated = Utc::now();
+  insight.update_count += 1;
 
   let existing_file_path = make_insight_path(&insight.topic, &insight.name)?;
   if !existing_file_path.exists() {
@@ -247,6 +285,9 @@ fn parse_legacy_format_no_frontmatter(content: &str) -> (InsightMetaData, String
     topic: "".to_string(),
     name: "".to_string(),
     overview,
+    created_at: default_created_at(),
+    last_updated: default_last_updated(),
+    update_count: 0,
     embedding_version: None,
     embedding: None,
     embedding_text: None,
@@ -264,6 +305,9 @@ fn parse_legacy_format(frontmatter_section: &str, body: &str) -> (InsightMetaDat
     topic: "".to_string(),
     name: "".to_string(),
     overview,
+    created_at: default_created_at(),
+    last_updated: default_last_updated(),
+    update_count: 0,
     embedding_version: None,
     embedding: None,
     embedding_text: None,
@@ -412,6 +456,7 @@ fn check_insight_exists(path: &std::path::Path, topic: &str, name: &str) -> Resu
 
 fn parse_insight_from_content(topic: &str, name: &str, content: &str) -> Result<Insight> {
   let (fm, details) = parse_insight_with_metadata(content)?;
+  
   Ok(Insight {
     // Use topic and name from frontmatter to preserve original case.
     // Fall back to parameters for backward compatibility.
@@ -419,6 +464,10 @@ fn parse_insight_from_content(topic: &str, name: &str, content: &str) -> Result<
     name: if !fm.name.is_empty() { fm.name } else { name.to_string() },
     overview: fm.overview,
     details,
+    // Handle temporal metadata with backwards compatibility
+    created_at: fm.created_at,
+    last_updated: fm.last_updated,
+    update_count: fm.update_count,
     embedding_version: fm.embedding_version,
     embedding: fm.embedding,
     embedding_text: fm.embedding_text,

--- a/crates/insights/src/server/models/insight.rs
+++ b/crates/insights/src/server/models/insight.rs
@@ -30,7 +30,7 @@ pub struct InsightMetaData {
   #[serde(default)]
   pub name: String,
   pub overview: String,
-  
+
   // Temporal metadata - always included in files
   #[serde(default = "default_created_at")]
   pub created_at: DateTime<Utc>,
@@ -38,7 +38,7 @@ pub struct InsightMetaData {
   pub last_updated: DateTime<Utc>,
   #[serde(default)]
   pub update_count: u32,
-  
+
   // Embedding metadata - excluded from files (set to None in write_to_file)
   #[serde(skip_serializing_if = "Option::is_none")]
   pub embedding_version: Option<String>,
@@ -456,7 +456,7 @@ fn check_insight_exists(path: &std::path::Path, topic: &str, name: &str) -> Resu
 
 fn parse_insight_from_content(topic: &str, name: &str, content: &str) -> Result<Insight> {
   let (fm, details) = parse_insight_with_metadata(content)?;
-  
+
   Ok(Insight {
     // Use topic and name from frontmatter to preserve original case.
     // Fall back to parameters for backward compatibility.


### PR DESCRIPTION
# Pull Request

This pull request adds temporal metadata (creation time, last updated time, and update count) to the `Insight` model, ensuring all insights track and persist this information. It updates the serialization/deserialization logic, provides backward compatibility for legacy insight files, and introduces comprehensive tests to validate the new behavior.

**Insight Model Enhancements**

* Added `created_at`, `last_updated`, and `update_count` fields to the `Insight` struct, and ensured these are set on creation and updated appropriately on modification. [[1]](diffhunk://#diff-11a3f62b55e21bb455fe2d4efa4263600f1c46f2617e4cf8c8cc275b0bbb5bc4R60-R64) [[2]](diffhunk://#diff-11a3f62b55e21bb455fe2d4efa4263600f1c46f2617e4cf8c8cc275b0bbb5bc4R74-R82) [[3]](diffhunk://#diff-11a3f62b55e21bb455fe2d4efa4263600f1c46f2617e4cf8c8cc275b0bbb5bc4R176-R179)
* Updated serialization logic to include temporal metadata in insight files, while keeping embedding data out of the files for readability.
* Provided default values for temporal metadata to maintain backward compatibility when loading legacy insight files that lack these fields. [[1]](diffhunk://#diff-11a3f62b55e21bb455fe2d4efa4263600f1c46f2617e4cf8c8cc275b0bbb5bc4R33-R42) [[2]](diffhunk://#diff-11a3f62b55e21bb455fe2d4efa4263600f1c46f2617e4cf8c8cc275b0bbb5bc4R288-R290) [[3]](diffhunk://#diff-11a3f62b55e21bb455fe2d4efa4263600f1c46f2617e4cf8c8cc275b0bbb5bc4R308-R310) [[4]](diffhunk://#diff-11a3f62b55e21bb455fe2d4efa4263600f1c46f2617e4cf8c8cc275b0bbb5bc4R459-R470)

**API and Handler Adjustments**

* Updated insight creation and embedding logic to use the new struct fields and constructors, ensuring temporal metadata is preserved and properly set throughout the handler flow. [[1]](diffhunk://#diff-533ece45ebedd82e4b4e208c7801f4470a9dd525bcc83bcc74b603b5eef56a22L412-R417) [[2]](diffhunk://#diff-533ece45ebedd82e4b4e208c7801f4470a9dd525bcc83bcc74b603b5eef56a22L664-R659)

**Testing Improvements**

* Added thorough unit tests to verify correct initialization, updating, serialization, and backward compatibility of temporal metadata in insights.

## Checklist
- [x] I have run `blizz do checks` and all checks pass
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] Any dependent changes have been merged and published
